### PR TITLE
Improve speed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-export default function indexToLineColumn(text, textIndex, {oneBased = false} = {}) {
-	if (textIndex < 0 || (textIndex >= text.length && text.length > 0)) {
-		throw new RangeError('Index out of bounds');
+function getPosition(text, textIndex) {
+	if (textIndex === 0) {
+		return {line: 0, column: 0};
 	}
 
 	const lineBreakBefore = text.lastIndexOf('\n', textIndex - 1);
@@ -13,5 +13,15 @@ export default function indexToLineColumn(text, textIndex, {oneBased = false} = 
 		}
 	}
 
-	return {line: oneBased ? line + 1 : line, column: oneBased ? column + 1 : column};
+	return {line, column};
+}
+
+export default function indexToLineColumn(text, textIndex, {oneBased = false} = {}) {
+	if (textIndex < 0 || (textIndex >= text.length && text.length > 0)) {
+		throw new RangeError('Index out of bounds');
+	}
+
+	const position = getPosition(text, textIndex);
+
+	return oneBased ? {line: position.line + 1, column: position.column + 1} : position;
 }

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ export default function indexToLineColumn(text, textIndex, {oneBased = false} = 
 		let index = lineBreakBefore;
 		index > 0;
 		index = text.lastIndexOf('\n', index - 1)
-	){
-			line++;
+	) {
+		line++;
 	}
 
 	return {line: oneBased ? line + 1 : line, column: oneBased ? column + 1 : column};

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ function getPosition(text, textIndex) {
 	let line = 0;
 	for (
 		let index = lineBreakBefore;
-		index > 0;
-		index = text.lastIndexOf('\n', index - 1)
+		index >= 0;
+		index = index === 0 ? -1 : text.lastIndexOf('\n', index - 1)
 	) {
 		line++;
 	}
@@ -27,6 +27,3 @@ export default function indexToLineColumn(text, textIndex, {oneBased = false} = 
 
 	return oneBased ? {line: position.line + 1, column: position.column + 1} : position;
 }
-
-
-console.log(indexToLineColumn('\na',1))

--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ export default function indexToLineColumn(text, textIndex, {oneBased = false} = 
 	const column = textIndex - lineBreakBefore - 1;
 
 	let line = 0;
-	for (let index = 0; index <= lineBreakBefore; index++) {
-		if (text.charAt(index) === '\n') {
+	for (
+		let index = lineBreakBefore;
+		index > 0;
+		index = text.lastIndexOf('\n', index - 1)
+	){
 			line++;
-		}
 	}
 
 	return {line: oneBased ? line + 1 : line, column: oneBased ? column + 1 : column};

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-function getPosition(text, textIndex) {
-	if (textIndex === 0) {
-		return {line: 0, column: 0};
-	}
+// Prevent `String#lastIndexOf` treat negative index as `0`
+const safeLastIndexOf = (string, searchString, index) =>
+	index < 0 ? -1 : string.lastIndexOf(searchString, index)
 
-	const lineBreakBefore = text.lastIndexOf('\n', textIndex - 1);
+function getPosition(text, textIndex) {
+	const lineBreakBefore = safeLastIndexOf(text, '\n', textIndex - 1);
 	const column = textIndex - lineBreakBefore - 1;
 
 	let line = 0;
 	for (
 		let index = lineBreakBefore;
 		index >= 0;
-		index = index === 0 ? -1 : text.lastIndexOf('\n', index - 1)
+		index = safeLastIndexOf(text, '\n', index - 1)
 	) {
 		line++;
 	}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // Prevent `String#lastIndexOf` treat negative index as `0`
 const safeLastIndexOf = (string, searchString, index) =>
-	index < 0 ? -1 : string.lastIndexOf(searchString, index)
+	index < 0 ? -1 : string.lastIndexOf(searchString, index);
 
 function getPosition(text, textIndex) {
 	const lineBreakBefore = safeLastIndexOf(text, '\n', textIndex - 1);

--- a/test.js
+++ b/test.js
@@ -54,12 +54,25 @@ test('CRLF', t => {
 });
 
 test('index on line break', t => {
-	const text = '\na\r\nb';
-	t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
-	t.deepEqual(indexToPosition(text, 1), {line: 1, column: 0});
-	t.deepEqual(indexToPosition(text, 2), {line: 1, column: 1});
-	t.deepEqual(indexToPosition(text, 3), {line: 1, column: 2});
-	t.deepEqual(indexToPosition(text, 4), {line: 2, column: 0});
+	{
+		const text = '\na\r\nb';
+		t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
+		t.deepEqual(indexToPosition(text, 1), {line: 1, column: 0});
+		t.deepEqual(indexToPosition(text, 2), {line: 1, column: 1});
+		t.deepEqual(indexToPosition(text, 3), {line: 1, column: 2});
+		t.deepEqual(indexToPosition(text, 4), {line: 2, column: 0});
+	}
+
+
+	{
+		const text = '\r\na\r\nb';
+		t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
+		t.deepEqual(indexToPosition(text, 1), {line: 0, column: 1});
+		t.deepEqual(indexToPosition(text, 2), {line: 1, column: 0});
+		t.deepEqual(indexToPosition(text, 3), {line: 1, column: 1});
+		t.deepEqual(indexToPosition(text, 4), {line: 1, column: 2});
+		t.deepEqual(indexToPosition(text, 5), {line: 2, column: 0});
+	}
 });
 
 test('mixed line endings', t => {

--- a/test.js
+++ b/test.js
@@ -54,11 +54,12 @@ test('CRLF', t => {
 });
 
 test('index on line break', t => {
-	const text = 'a\r\nb';
+	const text = '\na\r\nb';
 	t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
-	t.deepEqual(indexToPosition(text, 1), {line: 0, column: 1});
-	t.deepEqual(indexToPosition(text, 2), {line: 0, column: 2});
-	t.deepEqual(indexToPosition(text, 3), {line: 1, column: 0});
+	t.deepEqual(indexToPosition(text, 1), {line: 1, column: 0});
+	t.deepEqual(indexToPosition(text, 2), {line: 1, column: 1});
+	t.deepEqual(indexToPosition(text, 3), {line: 1, column: 2});
+	t.deepEqual(indexToPosition(text, 4), {line: 2, column: 0});
 });
 
 test('mixed line endings', t => {

--- a/test.js
+++ b/test.js
@@ -54,7 +54,6 @@ test('CRLF', t => {
 });
 
 test('index on line break', t => {
-<<<<<<< HEAD
 	{
 		const text = '\na\r\nb';
 		t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
@@ -63,7 +62,6 @@ test('index on line break', t => {
 		t.deepEqual(indexToPosition(text, 3), {line: 1, column: 2});
 		t.deepEqual(indexToPosition(text, 4), {line: 2, column: 0});
 	}
-
 
 	{
 		const text = '\r\na\r\nb';
@@ -74,14 +72,6 @@ test('index on line break', t => {
 		t.deepEqual(indexToPosition(text, 4), {line: 1, column: 2});
 		t.deepEqual(indexToPosition(text, 5), {line: 2, column: 0});
 	}
-=======
-	const text = '\na\r\nb';
-	t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
-	t.deepEqual(indexToPosition(text, 1), {line: 1, column: 0});
-	t.deepEqual(indexToPosition(text, 2), {line: 1, column: 1});
-	t.deepEqual(indexToPosition(text, 3), {line: 1, column: 2});
-	t.deepEqual(indexToPosition(text, 4), {line: 2, column: 0});
->>>>>>> main
 });
 
 test('mixed line endings', t => {


### PR DESCRIPTION
Use `lastIndexOf` seems faster.

As I tested on a 100 lines string locally, it's about 4x faster.

[perf online](https://perf.link/#eyJpZCI6InJ4YmdkMGthcWtmIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IHRleHQgPSAnZm9vIGJhclxcbicucmVwZWF0KDEwMCkiLCJ0ZXN0cyI6W3sibmFtZSI6Ikxvb3Agb25lIGJ5IG9uZSIsImNvZGUiOiJcdGxldCBsaW5lID0gMDtcblx0Zm9yIChsZXQgaW5kZXggPSAwOyBpbmRleCA8PSB0ZXh0Lmxlbmd0aDsgaW5kZXgrKykge1xuXHRcdGlmICh0ZXh0LmNoYXJBdChpbmRleCkgPT09ICdcXG4nKSB7XG5cdFx0XHRsaW5lKys7XG5cdFx0fVxuXHR9XG5cdFxuXHRpZiAobGluZSAhPT0gMTAwKSB7XG5cdCAgdGhyb3cgbmV3IEVycm9yKClcblx0fSIsInJ1bnMiOlsxMDAwLDcwMDAsMjkwMDAsMjYwMDAsNTAwMCw0MTAwMCw0MDAwLDQwMDAsNzAwMCw5MDAwLDI0MDAwLDIwMDAsOTAwMCw0MDAwLDQwMDAsNDAwMCwzMzAwMCwyMDAwLDI4MDAwLDYwMDAsMTMwMDAsMTUwMDAsNDAwMCwxNTAwMCwxMDAwMCw4MDAwLDMwMDAsMTcwMDAsNzAwMCwxMDAwMCwzMDAwMCwxOTAwMCwxMTAwMCwxNjAwMCw3MDAwLDQwMDAsMzAwMCwxNDAwMCw0MDAwLDEwMDAsMzIwMDAsMzEwMDAsNDAwMCw3MDAwLDEwMDAwLDEwMDAwLDcwMDAsMjAwMDAsMjAwMCw0MDAwLDUwMDAsNjAwMCw5MDAwLDYwMDAsNjAwMCwxMDAwLDgwMDAsMTkwMDAsMTAwMCw1MDAwLDQwMDAsMTUwMDAsNTAwMCw0MDAwLDYwMDAsMTAwMCw0MDAwLDkwMDAsMTAwMCw4MDAwLDEyMDAwLDI5MDAwLDYwMDAsMTAwMCw0MDAwLDM1MDAwLDE3MDAwLDIwMDAsMTMwMDAsMTMwMDAsMjYwMDAsNjAwMCw0MDAwLDI5MDAwLDQwMDAsMjYwMDAsMjIwMDAsMjEwMDAsNzAwMCwyMjAwMCwyMDAwLDIwMDAsMjgwMDAsMzEwMDAsMjUwMDAsODAwMCwxMDAwLDgwMDAsMjQwMDAsNDAwMF0sIm9wcyI6MTE0MjB9LHsibmFtZSI6IlN0cmluZyNsYXN0SW5kZXhPZiIsImNvZGUiOiJcdGxldCBsaW5lID0gMDtcblx0Zm9yIChcblx0XHRsZXQgaW5kZXggPSB0ZXh0Lmxlbmd0aCAtIDE7XG5cdFx0aW5kZXggPiAwO1xuXHRcdGluZGV4ID0gdGV4dC5sYXN0SW5kZXhPZignXFxuJywgaW5kZXggLSAxKVxuXHQpe1xuXHRcdFx0bGluZSsrO1xuXHR9XG5cdFxuXHRcblx0aWYgKGxpbmUgIT09IDEwMCkge1xuXHQgIHRocm93IG5ldyBFcnJvcigpXG5cdH0iLCJydW5zIjpbNTYwMDAsMjYwMDAsMTUwMDAsMTY0MDAwLDE1MjAwMCwyNDAwMCw5MDAwLDgzMDAwLDExMDAwLDQ5MDAwLDEzNTAwMCw4NzAwMCwxNTgwMDAsMTMyMDAwLDE1MjAwMCwyNjAwMCwxOTAwMCw2MDAwLDE5MDAwLDEyNTAwMCwxNzMwMDAsMTI1MDAwLDE1NDAwMCw5OTAwMCwxNTEwMDAsMTcwMDAsMzEwMDAsNDYwMDAsNzQwMDAsNTAwMDAsMTcwMDAsMTAzMDAwLDI4MDAwLDYwMDAsNjIwMDAsMTM4MDAwLDE2MTAwMCw0NzAwMCwyNjAwMCwzNjAwMCwxMDMwMDAsMTIzMDAwLDM1MDAwLDIwMDAsMTkwMDAsNDYwMDAsMjAwMCwzMTAwMCwxMDkwMDAsNjIwMDAsMjYwMDAsNDIwMDAsNDAwMCwyMjAwMCwxMTAwMCwyMDAwLDI2MDAwLDEyMDAwMCw3MjAwMCw2MDAwMCwzMjAwMCwxMDQwMDAsNjYwMDAsNjAwMCwyOTAwMCw2MDAwLDM0MDAwLDE0NDAwMCwzMDAwLDI4MDAwLDk3MDAwLDM4MDAwLDExNDAwMCw4MzAwMCw0OTAwMCwyNjAwMCw2MDAwLDkwMDAsMzAwMDAsMTAwMCwxMzAwMCw4NjAwMCwyODAwMCw1MDAwMCwzODAwMCw2MjAwMCw1NTAwMCw2MDAwMCwxMDAwLDQ3MDAwLDE2MTAwMCw1NjAwMCwxNDAwMDAsMTcwMDAsMTAwMDAsODMwMDAsOTMwMDAsNDMwMDAsNTEwMDAsNzgwMDBdLCJvcHMiOjU5ODYwfV0sInVwZGF0ZWQiOiIyMDIzLTExLTA5VDExOjM5OjIzLjE3M1oifQ%3D%3D)