### PR TITLE
Allow `index` equals to text length

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ export default function indexToLineColumn(text, textIndex, {oneBased = false} = 
 		throw new TypeError('Index parameter should be an integer');
 	}
 
-	if (textIndex < 0 || (textIndex >= text.length && text.length > 0)) {
+	if (textIndex < 0 || textIndex > text.length) {
 		throw new RangeError('Index out of bounds');
 	}
 

--- a/test.js
+++ b/test.js
@@ -38,9 +38,9 @@ test('last index - oneBased', t => {
 });
 
 test('index out of bounds', t => {
-	t.deepEqual(indexToPosition('', 0), {line:0, column:0});
-	t.deepEqual(indexToPosition('a', 1), {line:0, column:1});
-	t.deepEqual(indexToPosition('a\n', 2), {line:1, column:0});
+	t.deepEqual(indexToPosition('', 0), {line: 0, column: 0});
+	t.deepEqual(indexToPosition('a', 1), {line: 0, column: 1});
+	t.deepEqual(indexToPosition('a\n', 2), {line: 1, column: 0});
 
 	t.throws(() => {
 		indexToPosition('a', 2);

--- a/test.js
+++ b/test.js
@@ -38,8 +38,17 @@ test('last index - oneBased', t => {
 });
 
 test('index out of bounds', t => {
+	t.deepEqual(indexToPosition('', 0), {line:0, column:0});
+	t.deepEqual(indexToPosition('a', 1), {line:0, column:1});
+	t.deepEqual(indexToPosition('a\n', 2), {line:1, column:0});
+
 	t.throws(() => {
-		indexToPosition('hello\nworld\n!', 20);
+		indexToPosition('a', 2);
+	}, {
+		message: 'Index out of bounds',
+	});
+	t.throws(() => {
+		indexToPosition('a', -1);
 	}, {
 		message: 'Index out of bounds',
 	});


### PR DESCRIPTION
It's common to have a position point to EOF, let's allow the index to be `text.length`? 

We should able to remove these lines in `parse-json`


https://github.com/sindresorhus/parse-json/blob/6a7bae72889ff172cb44d58223097abb67e9f8c2/index.js#L88-L92