### PR TITLE
Improve performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const safeLastIndexOf = (string, searchString, index) =>
 function getPosition(text, textIndex) {
 	const lineBreakBefore = safeLastIndexOf(text, '\n', textIndex - 1);
 	if (lineBreakBefore === -1) {
-		return {line: 0, column: textIndex}
+		return {line: 0, column: textIndex};
 	}
 
 	return {
 		line: text.slice(0, lineBreakBefore + 1).match(/\n/g).length,
-		column: textIndex - lineBreakBefore - 1
+		column: textIndex - lineBreakBefore - 1,
 	};
 }
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
-// Prevent `String#lastIndexOf` treat negative index as `0`
-const safeLastIndexOf = (string, searchString, index) =>
-	index < 0 ? -1 : string.lastIndexOf(searchString, index);
-
 // Performance https://github.com/sindresorhus/index-to-position/pull/9
 function getPosition(text, textIndex) {
-	const lineBreakBefore = safeLastIndexOf(text, '\n', textIndex - 1);
+	const lineBreakBefore = textIndex === 0 ? -1 : text.lastIndexOf('\n', textIndex - 1);
 	if (lineBreakBefore === -1) {
 		return {line: 0, column: textIndex};
 	}

--- a/index.js
+++ b/index.js
@@ -2,20 +2,17 @@
 const safeLastIndexOf = (string, searchString, index) =>
 	index < 0 ? -1 : string.lastIndexOf(searchString, index);
 
+// Performance https://github.com/sindresorhus/index-to-position/pull/9
 function getPosition(text, textIndex) {
 	const lineBreakBefore = safeLastIndexOf(text, '\n', textIndex - 1);
-	const column = textIndex - lineBreakBefore - 1;
-
-	let line = 0;
-	for (
-		let index = lineBreakBefore;
-		index >= 0;
-		index = safeLastIndexOf(text, '\n', index - 1)
-	) {
-		line++;
+	if (lineBreakBefore === -1) {
+		return {line: 0, column: textIndex}
 	}
 
-	return {line, column};
+	return {
+		line: text.slice(0, lineBreakBefore + 1).match(/\n/g).length,
+		column: textIndex - lineBreakBefore - 1
+	};
 }
 
 export default function indexToLineColumn(text, textIndex, {oneBased = false} = {}) {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,8 @@
 // Performance https://github.com/sindresorhus/index-to-position/pull/9
 function getPosition(text, textIndex) {
 	const lineBreakBefore = textIndex === 0 ? -1 : text.lastIndexOf('\n', textIndex - 1);
-	if (lineBreakBefore === -1) {
-		return {line: 0, column: textIndex};
-	}
-
 	return {
-		line: text.slice(0, lineBreakBefore + 1).match(/\n/g).length,
+		line: lineBreakBefore === -1 ? 0 : text.slice(0, lineBreakBefore + 1).match(/\n/g).length,
 		column: textIndex - lineBreakBefore - 1,
 	};
 }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function getPosition(text, textIndex) {
 	};
 }
 
-export default function indexToLineColumn(text, textIndex, {oneBased = false} = {}) {
+export default function indexToPosition(text, textIndex, {oneBased = false} = {}) {
 	if (typeof text !== 'string') {
 		throw new TypeError('Text parameter should be a string');
 	}

--- a/test.js
+++ b/test.js
@@ -73,6 +73,14 @@ test('index on line break', t => {
 	}
 
 	{
+		const text = '\n\na';
+		t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
+		t.deepEqual(indexToPosition(text, 1), {line: 1, column: 0});
+		t.deepEqual(indexToPosition(text, 2), {line: 2, column: 0});
+		t.deepEqual(indexToPosition(text, 3), {line: 2, column: 1});
+	}
+
+	{
 		const text = '\r\na\r\nb';
 		t.deepEqual(indexToPosition(text, 0), {line: 0, column: 0});
 		t.deepEqual(indexToPosition(text, 1), {line: 0, column: 1});


### PR DESCRIPTION
In #6, I found that using `lastIndexOf` is faster than looping characters one by one.

Now I found that using an regular expression is somehow super fast

[perf link](https://perf.link/#eyJpZCI6InRjbHRvNHpraHdpIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IHRleHQgPSAnZm9vIGJhclxcbicucmVwZWF0KDIwMCkiLCJ0ZXN0cyI6W3sibmFtZSI6IlJlZ0V4cCIsImNvZGUiOiJmdW5jdGlvbiBjb3VudExpbmVzQmVmb3JlKHRleHQsIGVuZEluZGV4KXtcblx0cmV0dXJuIHRleHQuc2xpY2UoMCwgZW5kSW5kZXgpLm1hdGNoKC9cXG4vZykubGVuZ3RoXG59XG5cdFxuXHRpZiAoY291bnRMaW5lc0JlZm9yZSh0ZXh0LCB0ZXh0Lmxlbmd0aC8yKSAhPT0gMTAwKSB7XG5cdCAgdGhyb3cgbmV3IEVycm9yKClcblx0fSIsInJ1bnMiOlszNzQ1MDAsMzEzNTAwLDQ3MzUwMCw3MTE1MDAsMjU1NTAwLDcxNjAwMCwzMTgwMDAsNDgyMDAwLDYxMTUwMCw3MDI1MDAsNTg4MDAwLDc1MjUwMCw2NDgwMDAsMzY4NTAwLDYyNDAwMCw3MjcwMDAsNTU0NTAwLDc4MzAwMCw2MTcwMDAsMjU1NTAwLDQ2NjAwMCwxMDI0MDAwLDI3ODAwMCw2MTg1MDAsOTU2NTAwLDQ0ODAwMCw5MDk1MDAsODY1MDAwLDcwMjUwMCwyNTU1MDAsMjUyMDAwLDM2NTAwMCwyNDYwMDAsNTk3MDAwLDk0MjAwMCwzMzgwMDAsNzQwMDAwLDcyMjUwMCwyNTU1MDAsMzIxMDAwLDI1MzUwMCwxMzIwMDAsMzA3NTAwLDI1NTUwMCwyNTU1MDAsMjUzNTAwLDI4NTAwMCw1MTg1MDAsMjgwNTAwLDI1NTUwMCw0ODEwMDAsMjU1NTAwLDI1NTUwMCw0MTI1MDAsNzY1MDAwLDk1NjUwMCw0MzUwMDAsNTc5NTAwLDI1NTUwMCwzNTg1MDAsMjk4NTAwLDI1NTUwMCwyNTU1MDAsNDg1MDAwLDIzNzAwMCwyNTU1MDAsNTEzNTAwLDI1NTUwMCwyNTU1MDAsNDk2NTAwLDM1NTUwMCwyNTU1MDAsMjU1NTAwLDM1MjAwMCw3OTIwMDAsNDUyMDAwLDU2NzUwMCw2OTA1MDAsNDY1NTAwLDUxMTAwMCwyNTU1MDAsODkwNTAwLDMyMDAwMCw1MDcwMDAsMzAwNTAwLDcxMjUwMCwzNjMwMDAsOTU2NTAwLDQwNjAwMCwyNTU1MDAsNzQxNTAwLDEwMTQ1MDAsODQwNTAwLDU1OTAwMCwyNTU1MDAsNDExNTAwLDI1NTUwMCw3NTMwMDAsNTM1NTAwLDU1MTAwMF0sIm9wcyI6NDg2MjAwfSx7Im5hbWUiOiJMb29wIG9uZSBieSBvbmUiLCJjb2RlIjoiZnVuY3Rpb24gY291bnRMaW5lc0JlZm9yZSh0ZXh0LCBlbmRJbmRleCl7XG5cdGxldCBsaW5lID0gMDtcblx0Zm9yIChsZXQgaW5kZXggPSAwOyBpbmRleCA8PSBlbmRJbmRleDsgaW5kZXgrKykge1xuXHRcdGlmICh0ZXh0LmNoYXJBdChpbmRleCkgPT09ICdcXG4nKSB7XG5cdFx0XHRsaW5lKys7XG5cdFx0fVxuXHR9XG5cdHJldHVybiBsaW5lXG59XG5cdFxuXHRpZiAoY291bnRMaW5lc0JlZm9yZSh0ZXh0LCB0ZXh0Lmxlbmd0aC8yKSAhPT0gMTAwKSB7XG5cdCAgdGhyb3cgbmV3IEVycm9yKClcblx0fSIsInJ1bnMiOlsyMzAwMCwyMjUwMCwxNTAwMCwxNzUwMCwyMzAwMCwxNTUwMCw0MjUwMCwxMzAwMCw4MDAwLDI0MDAwLDEyNTAwLDM5MDAwLDI5MDAwLDg1MDAsMTI1MDAsMTk1MDAsMjc1MDAsMTUwMCw0NTAwMCw0NTAwLDE1MDAwLDU1MDAsODUwMCw4NTAwLDE0NTAwLDg1MDAsMTcwMDAsMTgwMDAsNDAwMDAsODUwMCw1NTAwLDM1MDAsNjUwMCwxMDAwMCwxNTUwMCwxMjUwMCwyNzAwMCwxODAwMCwyODUwMCwxMDUwMCwyMDAwLDU1MDAsNTAwMCw3NTAwLDM1MDAsNDAwMCwzNTAwLDc1MDAsNzUwMCw3MDAwLDUwMDAsODAwMCw1NTAwLDgwMDAsODUwMCwyODAwMCwxMjUwMCw4NTAwLDgwMDAsNjAwMCw4NTAwLDQwMDAsNzAwMCw2NTAwLDgwMDAsNTAwMCwzOTAwMCw3NTAwLDM1MDAsNTAwMCw1NTAwLDMwMDAsODUwMCw1MDAwLDEwNTAwLDcwMDAsODUwMCwxOTUwMCwxMTAwMCwyMjUwMCw3NTAwLDg1MDAsNzAwMCw3NTAwLDUwMDAsNzAwMCw4MDAwLDcwMDAsNTUwMCw4NTAwLDcwMDAsMTE1MDAsNzAwMCwzNTAwLDU1MDAsODAwMCw0NTAwLDg1MDAsNTAwMCw4NTAwXSwib3BzIjoxMTcxNX0seyJuYW1lIjoiU3RyaW5nI2xhc3RJbmRleE9mIiwiY29kZSI6ImZ1bmN0aW9uIGNvdW50TGluZXNCZWZvcmUodGV4dCwgZW5kSW5kZXgpe1xuXHRsZXQgbGluZSA9IDA7XG5cdGZvciAoXG5cdFx0bGV0IGluZGV4ID0gZW5kSW5kZXggLSAxO1xuXHRcdGluZGV4ID4gMDtcblx0XHRpbmRleCA9IHRleHQubGFzdEluZGV4T2YoJ1xcbicsIGluZGV4IC0gMSlcblx0KXtcblx0XHRcdGxpbmUrKztcblx0fVxuXHRyZXR1cm4gbGluZVxufVxuXHRcblx0XG5cdGlmIChjb3VudExpbmVzQmVmb3JlKHRleHQsIHRleHQubGVuZ3RoLzIpICE9PSAxMDApIHtcblx0ICB0aHJvdyBuZXcgRXJyb3IoKVxuXHR9IiwicnVucyI6WzExNTUwMCw2MzAwMCwxNjAwMCw0OTUwMCw0OTUwMCwxMDc1MDAsMTEzNTAwLDk5NTAwLDQ1NTAwLDcwMDAwLDEyMTUwMCwxMDcwMDAsNzYwMDAsMzY1MDAsMTEwNTAwLDUzMDAwLDY1NTAwLDU1NTAwLDY1NTAwLDQ2NTAwLDc3NTAwLDE1NjUwMCw1NTUwMCwxNjYwMDAsMTM3NTAwLDk4NTAwLDkxNTAwLDEwODAwMCwzNDUwMCwxNDAwMCw0MTAwMCw0MDAwLDQwMDAsMTM1NTAwLDExMTUwMCwxMTAwMDAsOTQwMDAsODMwMDAsODAwMDAsMjM1MDAsMjUwMCwzNzUwMCwyNDUwMCw4NTAwLDQxMDAwLDQwMDAsNDIwMDAsMjI1MDAsNDAwMCwxODAwMCw0MDAwLDQ4MDAwLDk1MDAwLDg1MDAwLDkwMDAwLDE0OTAwMCw4MTAwMCwxMTEwMDAsNzMwMDAsNDgwMDAsNjI1MDAsMTI1MDAsNDE1MDAsNDM1MDAsOTUwMCw0MDUwMCwxMDk1MDAsMjMwMDAsNDAwMCw1NTUwMCwzODAwMCw0MDAwLDkyNTAwLDQwMDAsODgwMDAsMTE2MDAwLDYwNTAwLDExNjUwMCw4MjAwMCw5NzUwMCwxMDAwMCw4NDUwMCwzNDUwMCw0MDAwLDMxMDAwLDg5MDAwLDY3NTAwLDQyMDAwLDUzMDAwLDUyMDAwLDI4MDAwLDEwNTAwMCwxMTMwMDAsMjUwMDAsNzY1MDAsODA1MDAsMzU1MDAsNzkwMDAsNTU1MDAsNzE1MDBdLCJvcHMiOjYzMTk1fV0sInVwZGF0ZWQiOiIyMDI1LTA0LTA4VDE0OjU2OjE0LjI1MFoifQ%3D%3D)