### PR TITLE
Add `oneBasedLine` and `oneBasedColumn` options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,20 @@ export type Options = {
 	@default false
 	*/
 	readonly oneBased?: boolean;
+
+	/**
+	Whether to use 1-based or 0-based line indexing for the result.
+
+	@default false
+	*/
+	readonly oneBasedLine?: boolean;
+
+	/**
+	Whether to use 1-based or 0-based column indexing for the result.
+
+	@default false
+	*/
+	readonly oneBasedColumn?: boolean;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,13 +1,22 @@
+const getOffsets = ({
+	oneBased,
+	oneBasedLine = oneBased,
+	oneBasedColumn = oneBased,
+} = {}) => [oneBasedLine ? 1 : 0, oneBasedColumn ? 1 : 0];
+
 // Performance https://github.com/sindresorhus/index-to-position/pull/9
-function getPosition(text, textIndex) {
+function getPosition(text, textIndex, options) {
 	const lineBreakBefore = textIndex === 0 ? -1 : text.lastIndexOf('\n', textIndex - 1);
+	const [lineOffset, columnOffset] = getOffsets(options);
 	return {
-		line: lineBreakBefore === -1 ? 0 : text.slice(0, lineBreakBefore + 1).match(/\n/g).length,
-		column: textIndex - lineBreakBefore - 1,
+		line: lineBreakBefore === -1
+			? lineOffset
+			: text.slice(0, lineBreakBefore + 1).match(/\n/g).length + lineOffset,
+		column: textIndex - lineBreakBefore - 1 + columnOffset,
 	};
 }
 
-export default function indexToPosition(text, textIndex, {oneBased = false} = {}) {
+export default function indexToPosition(text, textIndex, options) {
 	if (typeof text !== 'string') {
 		throw new TypeError('Text parameter should be a string');
 	}
@@ -20,7 +29,5 @@ export default function indexToPosition(text, textIndex, {oneBased = false} = {}
 		throw new RangeError('Index out of bounds');
 	}
 
-	const position = getPosition(text, textIndex);
-
-	return oneBased ? {line: position.line + 1, column: position.column + 1} : position;
+	return getPosition(text, textIndex, options);
 }

--- a/readme.md
+++ b/readme.md
@@ -57,4 +57,3 @@ Type: `boolean`\
 Default: `false`
 
 Whether to use 1-based or 0-based column indexing for the result.
-

--- a/readme.md
+++ b/readme.md
@@ -43,3 +43,18 @@ Type: `boolean`\
 Default: `false`
 
 Whether to use 1-based or 0-based indexing for the result.
+
+##### oneBasedLine
+
+Type: `boolean`\
+Default: `false`
+
+Whether to use 1-based or 0-based line indexing for the result.
+
+##### oneBasedColumn
+
+Type: `boolean`\
+Default: `false`
+
+Whether to use 1-based or 0-based column indexing for the result.
+

--- a/test.js
+++ b/test.js
@@ -97,10 +97,21 @@ test('mixed line endings', t => {
 	t.deepEqual(result, {line: 2, column: 0});
 });
 
-test('oneBased option', t => {
+test('options', t => {
 	const text = 'hello\nworld\n!';
-	const result = indexToPosition(text, 7, {oneBased: true});
-	t.deepEqual(result, {line: 2, column: 2});
+	const getPosition = options => indexToPosition(text, 7, options);
+
+	// Individual options
+	t.deepEqual(getPosition(), {line: 1, column: 1});
+	t.deepEqual(getPosition({oneBased: true}), {line: 2, column: 2});
+	t.deepEqual(getPosition({oneBasedLine: true}), {line: 2, column: 1});
+	t.deepEqual(getPosition({oneBasedColumn: true}), {line: 1, column: 2});
+	t.deepEqual(getPosition({oneBasedLine: true, oneBasedColumn: true}), {line: 2, column: 2});
+
+	// With `oneBased: true`
+	t.deepEqual(getPosition({oneBased: true, oneBasedLine: false}), {line: 1, column: 2});
+	t.deepEqual(getPosition({oneBased: true, oneBasedColumn: false}), {line: 2, column: 1});
+	t.deepEqual(getPosition({oneBased: true, oneBasedLine: false, oneBasedColumn: false}), {line: 1, column: 1});
 });
 
 test('empty text', t => {


### PR DESCRIPTION
It's common to use 1-based line number, but 0-based column number.

`@babel/code-frame` currently using 1-based line/column, but they plan to change the column to 0-based, https://github.com/babel/babel/issues/17316.

Let's allow control individually?